### PR TITLE
chore: use `Bun.write` so tests don't fail when `debug-output` is missing  

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ bun add circuit-json-to-step
 
 ```typescript
 import { circuitJsonToStep } from "circuit-json-to-step"
-import { writeFileSync } from "fs"
 
 const circuitJson = [
   {
@@ -43,8 +42,7 @@ const stepText = await circuitJsonToStep(circuitJson, {
   boardThickness: 1.6,
   productName: "MyPCB",
 })
-
-writeFileSync("output.step", stepText)
+await Bun.write("output.step", stepText)
 ```
 
 ## Related Projects

--- a/test/basics/basics01/basics01.test.ts
+++ b/test/basics/basics01/basics01.test.ts
@@ -1,4 +1,3 @@
-import { writeFileSync } from "node:fs"
 import { test, expect } from "bun:test"
 import { circuitJsonToStep } from "../../../lib/index"
 import { importStepWithOcct } from "../../utils/occt/importer"
@@ -34,7 +33,7 @@ test("basics01: convert circuit json with circular holes to STEP", async () => {
 
   // Write STEP file to debug-output
   const outputPath = "debug-output/basics01.step"
-  writeFileSync(outputPath, stepText)
+  await Bun.write(outputPath, stepText)
 
   console.log("✓ STEP file generated successfully")
   console.log(`  - Circles created: ${circleCount}`)

--- a/test/basics/basics02/basics02.test.ts
+++ b/test/basics/basics02/basics02.test.ts
@@ -1,4 +1,3 @@
-import { writeFileSync } from "node:fs"
 import { test, expect } from "bun:test"
 import { circuitJsonToStep } from "../../../lib/index"
 import { importStepWithOcct } from "../../utils/occt/importer"
@@ -19,7 +18,7 @@ test("basics02: convert pcb_board with outline only to STEP", async () => {
 
   // Write STEP file to debug-output
   const outputPath = "debug-output/basics02.step"
-  writeFileSync(outputPath, stepText)
+  await Bun.write(outputPath, stepText)
 
   console.log("✓ STEP file generated successfully")
   console.log(`  - STEP text length: ${stepText.length} bytes`)

--- a/test/basics/basics03/basics03.test.ts
+++ b/test/basics/basics03/basics03.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from "bun:test"
-import { writeFileSync } from "node:fs"
 import { circuitJsonToStep } from "../../../lib/index"
 import { importStepWithOcct } from "../../utils/occt/importer"
 import circuitJson from "./basics03.json"
@@ -19,7 +18,7 @@ test("basics03: convert pcb_board with arrow outline and pcb_plated_holes to STE
 
   // Write STEP file to debug-output
   const outputPath = "debug-output/basics03.step"
-  writeFileSync(outputPath, stepText)
+  await Bun.write(outputPath, stepText)
 
   console.log("✓ STEP file generated successfully")
   console.log(`  - STEP text length: ${stepText.length} bytes`)

--- a/test/basics/basics04/basics04.test.ts
+++ b/test/basics/basics04/basics04.test.ts
@@ -1,4 +1,3 @@
-import { writeFileSync } from "node:fs"
 import { test, expect } from "bun:test"
 import { circuitJsonToStep } from "../../../lib/index"
 import { importStepWithOcct } from "../../utils/occt/importer"
@@ -29,7 +28,7 @@ test("basics04: convert circuit json with components to STEP", async () => {
 
   // Write STEP file to debug-output
   const outputPath = "debug-output/basics04.step"
-  writeFileSync(outputPath, stepText)
+  await Bun.write(outputPath, stepText)
 
   console.log("✓ STEP file with components generated successfully")
   console.log(`  - Solids created: ${solidCount}`)

--- a/test/basics/basics05/basics05.test.ts
+++ b/test/basics/basics05/basics05.test.ts
@@ -1,4 +1,3 @@
-import { writeFileSync } from "node:fs"
 import { test, expect } from "bun:test"
 import { circuitJsonToStep } from "../../../lib/index"
 import { importStepWithOcct } from "../../utils/occt/importer"
@@ -34,7 +33,7 @@ test("basics05: new test to cause a diff error", async () => {
 
   // Write STEP file to debug-output
   const outputPath = "debug-output/basics05.step"
-  writeFileSync(outputPath, stepText)
+  await Bun.write(outputPath, stepText)
 
   console.log("✓ STEP file generated successfully")
   console.log(`  - Circles created: ${circleCount}`)

--- a/test/repros/repro01/repro01.test.ts
+++ b/test/repros/repro01/repro01.test.ts
@@ -1,4 +1,3 @@
-import { writeFileSync } from "node:fs"
 import { test, expect } from "bun:test"
 import { circuitJsonToStep } from "../../../lib/index"
 import { importStepWithOcct } from "../../utils/occt/importer"
@@ -28,7 +27,7 @@ test("basics04: convert circuit json with components to STEP", async () => {
 
   // Write STEP file to debug-output
   const outputPath = "debug-output/basics04.step"
-  writeFileSync(outputPath, stepText)
+  await Bun.write(outputPath, stepText)
 
   console.log("✓ STEP file with components generated successfully")
   console.log(`  - Solids created: ${solidCount}`)


### PR DESCRIPTION
## Summary  
Previously, running `bun test` caused failures whenever the `debug-output` directory did not exist because tests used `writeFileSync` (which throws if the parent directory is missing). Developers had to manually create `debug-output` after cloning.

This change replaces `writeFileSync` with `await Bun.write(...)` in the test suite and updates the README example to match.  
`Bun.write` automatically creates parent directories, so tests no longer fail due to a missing `debug-output` folder.

Before :
<img width="982" height="418" alt="image" src="https://github.com/user-attachments/assets/93b61694-c204-40d3-91bc-ed73d2ede87e" />

---


## Why  
- `Bun.write` creates parent directories automatically, removing the need for manualy creating a pre-existing `debug-output` folder.  
---

## How to Test  
Run locally (Bun required):

```bash
# run full test suite
bun test

# or run a single test
bun test test/basics/basics01/basics01.test.ts
```
Expected: tests no longer fail due to missing `debug-output` dir

