### PR TITLE
Add repro03: regression test for missing component boxes (issue #6)

### DIFF
--- a/test/repros/repro03/repro03.json
+++ b/test/repros/repro03/repro03.json
@@ -1,0 +1,78 @@
+[
+  {
+    "type": "pcb_board",
+    "pcb_board_id": "pcb_board_1",
+    "width": 40,
+    "height": 30,
+    "thickness": 1.6,
+    "center": { "x": 20, "y": 15 }
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_1",
+    "name": "R1",
+    "supplier_part_numbers": {},
+    "ftype": "simple_resistor"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_1",
+    "source_component_id": "source_component_1",
+    "center": { "x": 10, "y": 15 },
+    "width": 3.2,
+    "height": 1.6,
+    "layer": "top",
+    "rotation": 0
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_2",
+    "name": "R2",
+    "supplier_part_numbers": {},
+    "ftype": "simple_resistor"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_2",
+    "source_component_id": "source_component_2",
+    "center": { "x": 16, "y": 15 },
+    "width": 3.2,
+    "height": 1.6,
+    "layer": "top",
+    "rotation": 0
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_3",
+    "name": "R3",
+    "supplier_part_numbers": {},
+    "ftype": "simple_resistor"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_3",
+    "source_component_id": "source_component_3",
+    "center": { "x": 22, "y": 15 },
+    "width": 3.2,
+    "height": 1.6,
+    "layer": "top",
+    "rotation": 0
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_4",
+    "name": "R4",
+    "supplier_part_numbers": {},
+    "ftype": "simple_resistor"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_4",
+    "source_component_id": "source_component_4",
+    "center": { "x": 28, "y": 15 },
+    "width": 3.2,
+    "height": 1.6,
+    "layer": "top",
+    "rotation": 0
+  }
+]

--- a/test/repros/repro03/repro03.test.ts
+++ b/test/repros/repro03/repro03.test.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "bun:test"
+import { circuitJsonToStep } from "../../../lib/index"
+import { importStepWithOcct } from "../../utils/occt/importer"
+import circuitJson from "./repro03.json"
+
+/**
+ * Regression test for issue #6: component boxes (resistor blocks) were missing
+ * from STEP output because all component triangles were merged into a single
+ * ClosedShell, producing invalid topology that STEP viewers silently discard.
+ *
+ * The fix creates one ManifoldSolidBrep per component box, so each block appears
+ * as a separate solid. This test verifies the exact solid count so a regression
+ * would immediately fail.
+ */
+test("repro03: each component box appears as a separate solid in STEP output (issue #6)", async () => {
+  const COMPONENT_COUNT = 4 // R1, R2, R3, R4
+  const EXPECTED_SOLID_COUNT = COMPONENT_COUNT + 1 // board + 4 resistor boxes
+
+  const stepText = await circuitJsonToStep(circuitJson as any, {
+    includeComponents: true,
+    productName: "Repro03_ResistorBlocks",
+  })
+
+  // Verify STEP format
+  expect(stepText).toContain("ISO-10303-21")
+  expect(stepText).toContain("END-ISO-10303-21")
+
+  // Each component box must be its own ManifoldSolidBrep — the core fix for issue #6.
+  // Before the fix, all component triangles were merged into a single ClosedShell,
+  // yielding invalid topology and invisible boxes in STEP viewers.
+  const solidCount = (stepText.match(/MANIFOLD_SOLID_BREP/g) || []).length
+  expect(solidCount).toBe(EXPECTED_SOLID_COUNT)
+
+  // Write STEP file to debug-output
+  const outputPath = "debug-output/repro03.step"
+  await Bun.write(outputPath, stepText)
+
+  console.log(
+    `✓ STEP file generated with ${solidCount} solids (1 board + ${COMPONENT_COUNT} resistor boxes)`,
+  )
+  console.log(`  - STEP text length: ${stepText.length} bytes`)
+  console.log(`  - Output: ${outputPath}`)
+
+  // Validate STEP file can be imported with occt-import-js
+  const occtResult = await importStepWithOcct(stepText)
+  expect(occtResult.success).toBe(true)
+
+  // OCCT must produce at least one mesh per component box plus the board
+  expect(occtResult.meshes.length).toBeGreaterThanOrEqual(EXPECTED_SOLID_COUNT)
+
+  const [firstMesh] = occtResult.meshes
+  expect(firstMesh.attributes.position.array.length).toBeGreaterThan(0)
+  expect(firstMesh.index.array.length).toBeGreaterThan(0)
+
+  console.log(
+    `✓ STEP file validated by occt-import-js: ${occtResult.meshes.length} meshes`,
+  )
+}, 30000)


### PR DESCRIPTION
## Summary

Adds a focused regression test (`test/repros/repro03`) for issue #6 — component boxes (resistor blocks) were missing from STEP output.

### Root cause (from issue #6)

All component box triangles were merged into a single `ClosedShell`, producing one `ManifoldSolidBrep` covering all components. A STEP `ClosedShell` must be a single connected closed surface — multiple disconnected boxes form invalid topology that STEP viewers silently discard, making every component box invisible.

**Fix** (already applied): `createSceneBoxSolid` creates one `ManifoldSolidBrep` per component box.

### What this PR adds

- `test/repros/repro03/repro03.json` — minimal circuit with 4 resistors (R1–R4) on a 40×30 mm board, directly representing the "missing resistor blocks" scenario from the issue images
- `test/repros/repro03/repro03.test.ts` — asserts **exact** solid count (`= 1 board + 4 components`), so any regression back to the merged-shell approach would immediately fail; also validates with `occt-import-js` that ≥5 meshes are produced

The existing `basics04` test only checks `solidCount >= 1` (passes even with 0 component solids). The new test uses `toBe(5)` — a strict equality that would have caught the original bug.

All 12 tests pass locally (`bun test`).

---

/claim #6