### PR TITLE
Add regression guard for issue #6 — verify one solid per component box

### DIFF
--- a/test/basics/basics04/basics04.test.ts
+++ b/test/basics/basics04/basics04.test.ts
@@ -22,9 +22,12 @@ test("basics04: convert circuit json with components to STEP", async () => {
   expect(stepText).toContain("CIRCLE")
   expect(stepText).toContain("CYLINDRICAL_SURFACE")
 
-  // Verify we have multiple solids (board + components)
+  // Verify we have exactly 3 solids: 1 board + 2 component boxes (R1, C1).
+  // Issue #6: each component box must be its own ManifoldSolidBrep.
+  // Merging all boxes into a single ClosedShell creates invalid STEP
+  // topology that viewers silently discard, making rectangles invisible.
   const solidCount = (stepText.match(/MANIFOLD_SOLID_BREP/g) || []).length
-  expect(solidCount).toBeGreaterThanOrEqual(1)
+  expect(solidCount).toBe(3)
 
   // Write STEP file to debug-output
   const outputPath = "debug-output/basics04.step"

--- a/test/repros/repro01/repro01.test.ts
+++ b/test/repros/repro01/repro01.test.ts
@@ -21,9 +21,11 @@ test("basics04: convert circuit json with components to STEP", async () => {
   expect(stepText).toContain("CIRCLE")
   expect(stepText).toContain("CYLINDRICAL_SURFACE")
 
-  // Verify we have multiple solids (board + components)
+  // Verify each component gets its own solid (1 board + 4 component boxes = 5).
+  // Issue #6: merging all boxes into a single ClosedShell creates invalid
+  // STEP topology that viewers silently discard.
   const solidCount = (stepText.match(/MANIFOLD_SOLID_BREP/g) || []).length
-  expect(solidCount).toBeGreaterThanOrEqual(1)
+  expect(solidCount).toBe(5)
 
   // Write STEP file to debug-output
   const outputPath = "debug-output/repro01.step"


### PR DESCRIPTION
## What this PR does

Tightens test assertions from `>= 1` to exact solid counts to verify each component box gets its own `ManifoldSolidBrep` — preventing regression of issue #6 where merged boxes produced invalid STEP topology.

## How to test

```bash
bun test test/basics/basics04/basics04.test.ts
bun test test/repros/repro01/repro01.test.ts
```

## Before / After

**Before:** Tests used `expect(solidCount).toBeGreaterThanOrEqual(1)` — a weak check that would pass even if all boxes were incorrectly merged into a single `ClosedShell` (which STEP viewers silently discard, making rectangles invisible).

**After:** Exact assertions: `expect(solidCount).toBe(3)` for basics04 (1 board + 2 components: R1, C1) and `expect(solidCount).toBe(5)` for repro01 (1 board + 4 component boxes).

## Which issue this closes

Closes #6

## Context

The root cause fix (one `ManifoldSolidBrep` per component box) was incorporated via PRs #69, #71, and #76. This PR adds the regression guard to prevent the bug from returning.