### PR TITLE
test: guard component fallback solids

### DIFF
--- a/test/basics/basics04/basics04.test.ts
+++ b/test/basics/basics04/basics04.test.ts
@@ -22,9 +22,11 @@ test("basics04: convert circuit json with components to STEP", async () => {
   expect(stepText).toContain("CIRCLE")
   expect(stepText).toContain("CYLINDRICAL_SURFACE")
 
-  // Verify we have multiple solids (board + components)
+  // Verify we have one solid per disconnected body: board + R1 + C1.
+  // A board-only export would still contain one MANIFOLD_SOLID_BREP, so keep
+  // this exact count to guard against component boxes disappearing again.
   const solidCount = (stepText.match(/MANIFOLD_SOLID_BREP/g) || []).length
-  expect(solidCount).toBeGreaterThanOrEqual(1)
+  expect(solidCount).toBe(3)
 
   // Write STEP file to debug-output
   const outputPath = "debug-output/basics04.step"

--- a/test/repros/repro01/repro01.test.ts
+++ b/test/repros/repro01/repro01.test.ts
@@ -24,9 +24,11 @@ test("basics04: convert circuit json with components to STEP", async () => {
   expect(stepText).toContain("CIRCLE")
   expect(stepText).toContain("CYLINDRICAL_SURFACE")
 
-  // Verify we have multiple solids (board + components)
+  // Verify the repro keeps all fallback component rectangles as separate solids.
+  // The issue originally allowed missing component boxes to go unnoticed because
+  // a board-only STEP export still has one MANIFOLD_SOLID_BREP.
   const solidCount = (stepText.match(/MANIFOLD_SOLID_BREP/g) || []).length
-  expect(solidCount).toBeGreaterThanOrEqual(1)
+  expect(solidCount).toBe(5)
 
   // Write STEP file to debug-output
   const outputPath = "debug-output/repro01.step"


### PR DESCRIPTION
/claim #6

## Summary
- tighten STEP regression coverage for `basics04` and `repro01`
- assert the expected board + component solid counts instead of only checking for at least one solid
- document why the exact counts guard against component rectangles disappearing while a board-only export still passes basic STEP checks

## Tests
- `npx --yes bun test test/basics/basics04/basics04.test.ts test/repros/repro01/repro01.test.ts`
- `git diff --check`

Note: `npx --yes bun run format:check` reports CRLF formatting diagnostics across this Windows checkout, including many untouched files, so I kept the patch minimal and verified whitespace with `git diff --check`.