### PR TITLE
fix: generate fallback boxes for pcb_components without cad_component

### DIFF
--- a/lib/mesh-generation.ts
+++ b/lib/mesh-generation.ts
@@ -1,6 +1,5 @@
 import type { CircuitJson } from "circuit-json"
-import type { Ref, Repository } from "stepts"
-import { ManifoldSolidBrep } from "stepts"
+import type { Repository } from "stepts"
 import { getCircuitJsonToGltfModule } from "./get-circuit-json-to-gltf-module"
 import { createSceneBoxSolid } from "./scene-box-to-step"
 import type { GeneratedSceneSolid, SceneBox } from "./scene-geometry"
@@ -104,9 +103,83 @@ export async function generateComponentMeshes(
     for (const box of scene3d.boxes as SceneBox[]) {
       solids.push(createSceneBoxSolid(repo, box))
     }
+
+    // pcb_components that have no cad_component entry don't get a box from
+    // convertCircuitJsonTo3D. Generate fallback boxes from their footprint dims.
+    // Any pcb_component with a cad_component is considered covered — the designer
+    // explicitly specified a 3D model (or bounding box), so we don't override it.
+    const cadCoveredIds = new Set<string>(
+      (filteredCircuitJson as any[])
+        .filter((e) => e.type === "cad_component" && e.pcb_component_id)
+        .map((e) => e.pcb_component_id as string),
+    )
+
+    for (const box of createFallbackBoxesForUncoveredComponents(
+      filteredCircuitJson as any[],
+      cadCoveredIds,
+      boardThickness,
+    )) {
+      solids.push(createSceneBoxSolid(repo, box))
+    }
   } catch (error) {
     console.warn("Failed to generate component mesh:", error)
   }
 
   return solids
+}
+
+const COMPONENT_THICKNESS_MM = 0.6
+
+export function createFallbackBoxesForUncoveredComponents(
+  circuitJson: any[],
+  cadCoveredIds: Set<string>,
+  boardThickness: number,
+): SceneBox[] {
+  const sourceNames = new Map<string, string>()
+  for (const e of circuitJson) {
+    if (e.type === "source_component" && e.source_component_id && e.name) {
+      sourceNames.set(e.source_component_id, e.name)
+    }
+  }
+
+  const boxes: SceneBox[] = []
+  for (const e of circuitJson) {
+    if (e.type !== "pcb_component") continue
+    if (cadCoveredIds.has(e.pcb_component_id)) continue
+    // obstructs_within_bounds marks a layout-group placeholder, not a physical part
+    if (e.obstructs_within_bounds) continue
+
+    const cx = Number(e.center?.x)
+    const cy = Number(e.center?.y)
+    const w = Number(e.width)
+    const h = Number(e.height)
+    if (
+      !Number.isFinite(cx) ||
+      !Number.isFinite(cy) ||
+      !Number.isFinite(w) ||
+      !Number.isFinite(h)
+    )
+      continue
+    if (w <= 0 || h <= 0) continue
+
+    const isBottom = e.layer === "bottom"
+    const vertSign = isBottom ? -1 : 1
+    const boxCenterY =
+      vertSign * (boardThickness / 2 + COMPONENT_THICKNESS_MM / 2)
+    const rotDeg = Number(e.rotation ?? 0)
+
+    boxes.push({
+      center: { x: cx, y: boxCenterY, z: cy },
+      size: { x: w, y: COMPONENT_THICKNESS_MM, z: h },
+      rotation:
+        Number.isFinite(rotDeg) && rotDeg !== 0
+          ? { x: 0, y: (-rotDeg * Math.PI) / 180, z: 0 }
+          : undefined,
+      label:
+        sourceNames.get(e.source_component_id) ??
+        e.pcb_component_id ??
+        "Component",
+    })
+  }
+  return boxes
 }

--- a/test/repros/repro04/repro04.json
+++ b/test/repros/repro04/repro04.json
@@ -1,0 +1,44 @@
+[
+  {
+    "type": "pcb_board",
+    "pcb_board_id": "pcb_board_1",
+    "center": { "x": 0, "y": 0 },
+    "width": 30,
+    "height": 20,
+    "thickness": 1.6
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_1",
+    "name": "R1",
+    "supplier_part_numbers": {},
+    "ftype": "simple_resistor"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_1",
+    "source_component_id": "source_component_1",
+    "center": { "x": 5, "y": 5 },
+    "width": 3.2,
+    "height": 1.6,
+    "layer": "top",
+    "rotation": 0
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_2",
+    "name": "C1",
+    "supplier_part_numbers": {},
+    "ftype": "simple_capacitor"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_2",
+    "source_component_id": "source_component_2",
+    "center": { "x": -5, "y": -3 },
+    "width": 2.0,
+    "height": 1.25,
+    "layer": "bottom",
+    "rotation": 90
+  }
+]

--- a/test/repros/repro04/repro04.test.ts
+++ b/test/repros/repro04/repro04.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test"
+import { circuitJsonToStep } from "../../../lib/index"
+import { importStepWithOcct } from "../../utils/occt/importer"
+import circuitJson from "./repro04.json"
+
+test("repro04: pcb_components without cad_component produce fallback box solids", async () => {
+  const stepText = await circuitJsonToStep(circuitJson as any, {
+    includeComponents: true,
+    productName: "Repro04",
+  })
+
+  expect(stepText).toContain("ISO-10303-21")
+  expect(stepText).toContain("END-ISO-10303-21")
+  expect(stepText).toContain("Repro04")
+
+  // Board + 2 component fallback boxes = 3 solids
+  const solidCount = (stepText.match(/MANIFOLD_SOLID_BREP/g) ?? []).length
+  expect(solidCount).toBe(3)
+
+  const outputPath = "debug-output/repro04.step"
+  await Bun.write(outputPath, stepText)
+
+  const occtResult = await importStepWithOcct(stepText)
+  expect(occtResult.success).toBe(true)
+  expect(occtResult.meshes.length).toBeGreaterThanOrEqual(3)
+}, 30000)


### PR DESCRIPTION
## Root cause

`convertCircuitJsonTo3D` (from `circuit-json-to-gltf`) only emits a scene box for a component when a `cad_component` entry exists with either `show_as_bounding_box: true` or `footprinter_string`. A bare `pcb_component` with no `cad_component` is silently skipped — so the STEP output contains only the board, with no component blocks.

## Fix

After collecting boxes from the GLTF converter, `generateComponentMeshes` now calls `createFallbackBoxesForUncoveredComponents`, which:
1. Builds a set of `pcb_component_id`s that already have a `cad_component` entry (any designer-specified CAD model is respected as-is).
2. For the remaining `pcb_component` entries, generates a `SceneBox` from the footprint's `width`, `height`, `center`, `layer`, and `rotation` fields.
3. Skips entries with `obstructs_within_bounds: true` — those are subcircuit layout containers, not physical parts.

Component thickness defaults to **0.6 mm** (matching the existing repro01 fixture).

## Test

`test/repros/repro04/` — two SMD components (one top-layer, one bottom-layer rotated 90°) with no `cad_component` entries. Before the fix: 1 solid (board only). After: 3 solids (board + 2 component boxes), validated with OCCT.

## CI

- format-check: ✓
- type-check: ✓
- bun-test: ✓ (14/14 pass)

/claim #6