### PR TITLE
Tighten external STEP solid count guards

### DIFF
--- a/test/basics/basics06/basics06.test.ts
+++ b/test/basics/basics06/basics06.test.ts
@@ -45,11 +45,12 @@ test("basics06: skip mesh generation when all components have model_step_url", a
 
   expect(stepText).toContain("CYLINDRICAL_SURFACE")
 
-  // Should have multiple solids: board + 2 external STEP components
+  // Should have exactly the board plus the two unique external STEP models.
+  // A weaker >= check would miss regressions that drop or duplicate model solids.
 
   const solidCount = (stepText.match(/MANIFOLD_SOLID_BREP/g) || []).length
 
-  expect(solidCount).toBeGreaterThanOrEqual(3)
+  expect(solidCount).toBe(3)
 
   // Write STEP file to debug-output
 

--- a/test/repros/kicad-step/kicad-step.test.ts
+++ b/test/repros/kicad-step/kicad-step.test.ts
@@ -25,6 +25,7 @@ const EXPECTED_UNIQUE_STEP_MODEL_COUNT = new Set(
     .filter((item) => item.type === "cad_component" && item.model_step_url)
     .map((item) => item.model_step_url),
 ).size
+const EXPECTED_SOLID_COUNT = 1 + EXPECTED_UNIQUE_STEP_MODEL_COUNT
 
 const fixturesDir = fileURLToPath(
   new URL("../../fixtures/kicad-models/", import.meta.url),
@@ -109,7 +110,9 @@ test("kicad-step: merges KiCad STEP models referenced via model_step_url", async
 
   expect(stepText).toContain("KiCadStepMerge")
   const solidCount = (stepText.match(/MANIFOLD_SOLID_BREP/g) || []).length
-  expect(solidCount).toBeGreaterThanOrEqual(3)
+  // The STEP merge should define one board solid and one reusable solid per
+  // unique external model. Component instances are MAPPED_ITEM references.
+  expect(solidCount).toBe(EXPECTED_SOLID_COUNT)
 
   const repository = parseRepository(stepText)
   const solids = Array.from(repository.entries())
@@ -123,9 +126,7 @@ test("kicad-step: merges KiCad STEP models referenced via model_step_url", async
   )
   expect(boardSolids.length).toBe(1)
   const uniqueComponentSolids = solids.length - boardSolids.length
-  expect(uniqueComponentSolids).toBeGreaterThanOrEqual(
-    EXPECTED_UNIQUE_STEP_MODEL_COUNT,
-  )
+  expect(uniqueComponentSolids).toBe(EXPECTED_UNIQUE_STEP_MODEL_COUNT)
   expect(stepText.match(/MAPPED_ITEM/g) ?? []).toHaveLength(
     EXPECTED_COMPONENT_CENTERS.length,
   )


### PR DESCRIPTION
/claim #6

Contributes to #6

Summary:
- tighten `basics06` so the external STEP-only fixture must emit exactly the board plus two unique external model solids
- tighten the KiCad STEP merge repro so it must emit exactly one board solid plus one reusable solid per unique external STEP model
- keep the existing mapped-instance checks so duplicated component placements still validate through `MAPPED_ITEM`

This is a narrow regression guard for the external STEP merge path; it does not overlap with the generated component-box solid count guard or pcb_component fallback-box implementation PRs.

Demo:
https://github.com/digzrow-coder/circuit-json-to-step/releases/download/pr-96-demo-20260515/pr-96-external-step-solid-guards-demo.mp4

Tests:
- bun test test\basics\basics06\basics06.test.ts test\repros\kicad-step\kicad-step.test.ts
- bun test --timeout 30000 test\get-circuit-json-to-gltf-module.test.ts
- bun test
- bun x tsc --noEmit
- bun x biome format test/basics/basics06/basics06.test.ts test/repros/kicad-step/kicad-step.test.ts
- bun run build
- git diff --check

Local verification rerun before adding the demo:
- focused basics06 + kicad-step command: 4 pass, 0 fail
- get-circuit-json-to-gltf-module with explicit 30s timeout: 1 pass, 0 fail

Note: GitHub code checks are green (`test`, `format-check`, `type-check`). The remaining Vercel status is the tscircuit team authorization gate, not a branch code failure.

AI-assisted with OpenAI Codex; I reviewed the diff, proof asset, and validation output before posting.