### PR TITLE
test(basics04,repro01): assert exact solid count to lock in #6 fix

### DIFF
--- a/test/basics/basics04/basics04.test.ts
+++ b/test/basics/basics04/basics04.test.ts
@@ -22,9 +22,13 @@ test("basics04: convert circuit json with components to STEP", async () => {
   expect(stepText).toContain("CIRCLE")
   expect(stepText).toContain("CYLINDRICAL_SURFACE")
 
-  // Verify we have multiple solids (board + components)
+  // Verify we have multiple solids (board + components).
+  // basics04 has exactly 2 source_components (R1 + C1) plus the board, so the
+  // STEP must emit exactly 3 MANIFOLD_SOLID_BREP entities. A loose `>= 1`
+  // assertion would silently mask a regression that drops component fallback
+  // boxes — which is the original issue #6 failure mode.
   const solidCount = (stepText.match(/MANIFOLD_SOLID_BREP/g) || []).length
-  expect(solidCount).toBeGreaterThanOrEqual(1)
+  expect(solidCount).toBe(3)
 
   // Write STEP file to debug-output
   const outputPath = "debug-output/basics04.step"

--- a/test/repros/repro01/repro01.test.ts
+++ b/test/repros/repro01/repro01.test.ts
@@ -24,9 +24,12 @@ test("basics04: convert circuit json with components to STEP", async () => {
   expect(stepText).toContain("CIRCLE")
   expect(stepText).toContain("CYLINDRICAL_SURFACE")
 
-  // Verify we have multiple solids (board + components)
+  // repro01 has 4 source_components plus the board (= 5 solids expected).
+  // The loose `>= 1` assertion this replaces would have passed even if every
+  // component fallback box silently disappeared — which is issue #6's
+  // original failure. Asserting exact count makes the regression observable.
   const solidCount = (stepText.match(/MANIFOLD_SOLID_BREP/g) || []).length
-  expect(solidCount).toBeGreaterThanOrEqual(1)
+  expect(solidCount).toBe(5)
 
   // Write STEP file to debug-output
   const outputPath = "debug-output/repro01.step"


### PR DESCRIPTION
## Summary

test(basics04,repro01): assert exact solid count to lock in #6 fix



test(basics04): assert exact solid count (board + R1 + C1 = 3)

Companion to the repro01 tightening in 405b8b3. Locks in issue #6's fix
by replacing the loose '>= 1' assertion with an exact count, so any
regression that drops the per-component fallback boxes will fail this
test rather than silently passing.



## Diff

```
 test/basics/basics04/basics04.test.ts | 8 ++++++--
 test/repros/repro01/repro01.test.ts   | 7 +++++--
 2 files changed, 11 insertions(+), 4 deletions(-)
```

## Claim

/claim #6
