### PR TITLE
test(repro02,repro03): assert exact board solid count to guard hole-cut and wrapper-exclusion paths

### DIFF
--- a/test/repros/repro02/repro02.test.ts
+++ b/test/repros/repro02/repro02.test.ts
@@ -55,11 +55,20 @@ test("repro02: convert circuit json with rotated pill holes to STEP", async () =
   expect(stepText).toContain("CIRCLE")
   expect(stepText).toContain("CYLINDRICAL_SURFACE")
 
+  // Guard against #6 regression: complex rotated-pill hole cutting must
+  // produce exactly one board solid. This fixture has source_components
+  // (MP1-4, Xpattern1-4) but no pcb_component entries, so no component
+  // fallback boxes should be generated. A regression that fragments the
+  // board geometry or adds spurious component boxes would change this count.
+  const solidCount = (stepText.match(/MANIFOLD_SOLID_BREP/g) || []).length
+  expect(solidCount).toBe(1)
+
   // Write STEP file to debug-output
   const outputPath = "debug-output/repro02.step"
   await Bun.write(outputPath, stepText)
 
   console.log("✓ STEP file generated successfully")
+  console.log(`  - Solids created: ${solidCount}`)
   console.log(`  - STEP text length: ${stepText.length} bytes`)
   console.log(`  - Output: ${outputPath}`)
 

--- a/test/repros/repro03/repro03.test.ts
+++ b/test/repros/repro03/repro03.test.ts
@@ -12,15 +12,27 @@ test("repro03: reproduces fallback boxes for hole wrapper components", async () 
   expect(stepText).toContain("ISO-10303-21")
   expect(stepText).toContain("END-ISO-10303-21")
   expect(stepText).toContain("Repro03")
+  expect(stepText).toContain("MANIFOLD_SOLID_BREP")
   expect(stepText).toContain("CYLINDRICAL_SURFACE")
 
-  // Current repro behavior: these are fallback boxes for wrapper components,
-  // not intended physical component models.
+  // Guard: hole-wrapper pcb_components (subcircuit containers with
+  // obstructs_within_bounds) must NOT receive fallback component boxes.
+  // Any regression restoring the erroneous fallback would reintroduce
+  // these labels in the STEP output.
   expect(stepText).not.toContain("Xpattern1")
   expect(stepText).not.toContain("Xpattern4")
 
+  // Guard against #6 regression: since all pcb_components in this fixture
+  // are hole-wrapper containers, no component fallback boxes should be
+  // generated — the STEP output must contain exactly one board solid.
+  const solidCount = (stepText.match(/MANIFOLD_SOLID_BREP/g) || []).length
+  expect(solidCount).toBe(1)
+
   const outputPath = "debug-output/repro03.step"
   await Bun.write(outputPath, stepText)
+
+  console.log("\u2713 STEP file generated successfully")
+  console.log(`  - Solids created: ${solidCount}`)
 
   const occtResult = await importStepWithOcct(stepText)
   expect(occtResult.success).toBe(true)


### PR DESCRIPTION
## Summary

Tightens STEP regression coverage for two board-only fixtures that were previously guarded only by a loose `meshes.length > 0` OCCT import check.

### repro02 — rotated-pill hole board

Adds an exact `solidCount` assertion after the existing `MANIFOLD_SOLID_BREP` presence check:

```typescript
const solidCount = (stepText.match(/MANIFOLD_SOLID_BREP/g) || []).length
expect(solidCount).toBe(1)
```

**Why 1?** `repro02.json` contains `source_components` (MP1-4, Xpattern1-4) but **no `pcb_component` entries**. The STEP converter only generates component boxes for `cad_component` records. Without those, the board itself is the only solid. A regression that:
- fragments the board during rotated-pill hole subtraction, or
- adds spurious boxes for source-only components

…would cause `solidCount > 1` and fail this guard.

### repro03 — hole-wrapper component exclusion

Adds two new assertions:

1. `expect(stepText).toContain("MANIFOLD_SOLID_BREP")` — basic presence check (was missing)
2. `solidCount = 1` guard — hole-wrapper pcb_components must never receive fallback boxes

**Why 1?** All `pcb_component` entries in `repro03.json` are subcircuit hole-wrapper containers (`obstructs_within_bounds`). Restoring the erroneous fallback that generates boxes for these wrappers would push `solidCount` above 1 and fail the test — exactly the regression `repro03` was designed to catch.

## Non-overlap with existing open PRs

| PR | Files changed |
|---|---|
| #94, #97 | `basics04`, `repro01` |
| #96 | `basics06`, `kicad-step` |
| #95 | `repro04` + production fallback code |
| #98 | Production code (`pcb_silkscreen_rect`, `pcb_smtpad`) |
| **This PR** | `repro02`, `repro03` — untouched by all above |

No conflicts, purely additive test assertions on two fixtures not covered by any open PR.

/claim #6