### PR TITLE
Bump circuit-json-to-gltf dependency to v0.0.101

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "circuit-json-to-connectivity-map": "^0.0.22",
-    "circuit-json-to-gltf": "^0.0.100",
+    "circuit-json-to-gltf": "^0.0.101",
     "circuit-to-svg": "^0.0.345",
     "schematic-symbols": "^0.0.202",
     "stepts": "^0.0.4"


### PR DESCRIPTION
### Motivation
- Update the `circuit-json-to-gltf` dependency to pull in the latest patch release (`0.0.101`) which likely contains bugfixes or improvements needed by the project.

### Description
- Incremented the `circuit-json-to-gltf` version in `package.json` from `^0.0.100` to `^0.0.101`.

### Testing
- Ran the automated test suite with `bun test` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0c7f2589288327a1cb9aeeb6b9183a)