### PR TITLE
test: guard board-only STEP solid counts

### DIFF
--- a/test/basics/basics01/basics01.test.ts
+++ b/test/basics/basics01/basics01.test.ts
@@ -18,6 +18,8 @@ test("basics01: convert circuit json with circular holes to STEP", async () => {
   // Verify product structure
   expect(stepText).toContain("TestPCB")
   expect(stepText).toContain("MANIFOLD_SOLID_BREP")
+  const solidCount = (stepText.match(/MANIFOLD_SOLID_BREP/g) || []).length
+  expect(solidCount).toBe(1)
 
   // Verify holes are created (should have CIRCLE and CYLINDRICAL_SURFACE entities)
   expect(stepText).toContain("CIRCLE")
@@ -37,6 +39,7 @@ test("basics01: convert circuit json with circular holes to STEP", async () => {
 
   console.log("✓ STEP file generated successfully")
   console.log(`  - Circles created: ${circleCount}`)
+  console.log(`  - Solids created: ${solidCount}`)
   console.log(`  - STEP text length: ${stepText.length} bytes`)
   console.log(`  - Output: ${outputPath}`)
 

--- a/test/basics/basics02/basics02.test.ts
+++ b/test/basics/basics02/basics02.test.ts
@@ -15,12 +15,15 @@ test("basics02: convert pcb_board with outline only to STEP", async () => {
   // Verify product structure
   expect(stepText).toContain("TestPCB_Outline")
   expect(stepText).toContain("MANIFOLD_SOLID_BREP")
+  const solidCount = (stepText.match(/MANIFOLD_SOLID_BREP/g) || []).length
+  expect(solidCount).toBe(1)
 
   // Write STEP file to debug-output
   const outputPath = "debug-output/basics02.step"
   await Bun.write(outputPath, stepText)
 
   console.log("✓ STEP file generated successfully")
+  console.log(`  - Solids created: ${solidCount}`)
   console.log(`  - STEP text length: ${stepText.length} bytes`)
   console.log(`  - Output: ${outputPath}`)
 

--- a/test/basics/basics03/basics03.test.ts
+++ b/test/basics/basics03/basics03.test.ts
@@ -15,12 +15,15 @@ test("basics03: convert pcb_board with arrow outline and pcb_plated_holes to STE
   // Verify product structure
   expect(stepText).toContain("TestPCB_ArrowWithPlatedHoles")
   expect(stepText).toContain("MANIFOLD_SOLID_BREP")
+  const solidCount = (stepText.match(/MANIFOLD_SOLID_BREP/g) || []).length
+  expect(solidCount).toBe(1)
 
   // Write STEP file to debug-output
   const outputPath = "debug-output/basics03.step"
   await Bun.write(outputPath, stepText)
 
   console.log("✓ STEP file generated successfully")
+  console.log(`  - Solids created: ${solidCount}`)
   console.log(`  - STEP text length: ${stepText.length} bytes`)
   console.log(`  - Output: ${outputPath}`)
 

--- a/test/basics/basics05/basics05.test.ts
+++ b/test/basics/basics05/basics05.test.ts
@@ -18,6 +18,8 @@ test("basics05: new test to cause a diff error", async () => {
   // Verify product structure
   expect(stepText).toContain("TestPCB_DiffError")
   expect(stepText).toContain("MANIFOLD_SOLID_BREP")
+  const solidCount = (stepText.match(/MANIFOLD_SOLID_BREP/g) || []).length
+  expect(solidCount).toBe(1)
 
   // Verify holes are created (should have CIRCLE and CYLINDRICAL_SURFACE entities)
   expect(stepText).toContain("CIRCLE")
@@ -37,6 +39,7 @@ test("basics05: new test to cause a diff error", async () => {
 
   console.log("✓ STEP file generated successfully")
   console.log(`  - Circles created: ${circleCount}`)
+  console.log(`  - Solids created: ${solidCount}`)
   console.log(`  - STEP text length: ${stepText.length} bytes`)
   console.log(`  - Output: ${outputPath}`)
 


### PR DESCRIPTION
## Summary
- add exact `MANIFOLD_SOLID_BREP` count assertions for the board-only baseline fixtures: `basics01`, `basics02`, `basics03`, and `basics05`
- keep this separate from the existing component-box and repro regression guards by only touching board-only fixtures
- log the verified solid count alongside existing STEP debug output

## Why
These fixtures previously only asserted that at least one STEP solid/imported mesh existed. That would still pass if a regression accidentally fragmented a board into extra solids or emitted component fallback boxes for inputs that contain only a board/holes. Each of these fixtures should produce exactly one board solid.

## Verification
- `bun test test/basics/basics01/basics01.test.ts test/basics/basics02/basics02.test.ts test/basics/basics03/basics03.test.ts test/basics/basics05/basics05.test.ts` -> 4 pass
- `bun test` -> 13 pass
- `bun run format:check` -> passed
- `bun run build` -> passed
- `git diff --check` -> passed

/claim #6