### PR TITLE
Render STEP-backed components as fallback boxes when external meshes are disabled

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -572,7 +572,10 @@ export async function circuitJsonToStep(
   let handledComponentIds = new Set<string>()
   let handledPcbComponentIds = new Set<string>()
 
-  if (options.includeComponents && options.includeExternalMeshes) {
+  const shouldUseExternalStepModels =
+    options.includeComponents && options.includeExternalMeshes
+
+  if (shouldUseExternalStepModels) {
     const mergeResult = await mergeExternalStepModels({
       repo,
       circuitJson,
@@ -590,15 +593,18 @@ export async function circuitJsonToStep(
   // Generate component mesh fallback if requested
   // Only call mesh generation if there are components that need it
   if (options.includeComponents) {
-    // Build set of pcb_component_ids covered by cad_components with model_step_url
+    // Build set of pcb_component_ids covered by cad_components with model_step_url.
+    // STEP-backed components are only covered when external mesh merging is enabled.
     const pcbComponentIdsWithStepUrl = new Set<string>()
-    for (const item of circuitJson) {
-      if (
-        item.type === "cad_component" &&
-        item.model_step_url &&
-        item.pcb_component_id
-      ) {
-        pcbComponentIdsWithStepUrl.add(item.pcb_component_id)
+    if (options.includeExternalMeshes) {
+      for (const item of circuitJson) {
+        if (
+          item.type === "cad_component" &&
+          item.model_step_url &&
+          item.pcb_component_id
+        ) {
+          pcbComponentIdsWithStepUrl.add(item.pcb_component_id)
+        }
       }
     }
 
@@ -621,8 +627,9 @@ export async function circuitJsonToStep(
         ) {
           return false
         }
-        // Needs mesh if no model_step_url
-        return !item.model_step_url
+        // Needs fallback mesh when it has no external STEP model, or when
+        // external mesh merging is disabled and the STEP URL is intentionally ignored.
+        return !item.model_step_url || !options.includeExternalMeshes
       }
       if (item.type === "pcb_component") {
         // Skip if already handled

--- a/lib/mesh-generation.ts
+++ b/lib/mesh-generation.ts
@@ -65,7 +65,11 @@ export async function generateComponentMeshes(
           return false
         }
 
-        if (element.type === "cad_component" && element.model_step_url) {
+        if (
+          includeExternalMeshes &&
+          element.type === "cad_component" &&
+          element.model_step_url
+        ) {
           return false
         }
 
@@ -86,8 +90,10 @@ export async function generateComponentMeshes(
             model_3mf_url: undefined,
             model_obj_url: undefined,
             model_stl_url: undefined,
+            model_step_url: undefined,
             model_glb_url: undefined,
             model_gltf_url: undefined,
+            show_as_bounding_box: true,
           }
         }
 

--- a/test/basics/basics06/basics06.test.ts
+++ b/test/basics/basics06/basics06.test.ts
@@ -87,3 +87,22 @@ test("basics06: skip mesh generation when all components have model_step_url", a
 
   await expect(stepText).toMatchStepSnapshot(import.meta.path, "basics06")
 }, 30000)
+
+test("basics06: falls back to component boxes when external meshes are disabled", async () => {
+  const stepText = await circuitJsonToStep(circuitJson as any, {
+    includeComponents: true,
+    includeExternalMeshes: false,
+    productName: "TestPCB_FallbackBoxes",
+  })
+
+  expect(stepText).toContain("TestPCB_FallbackBoxes")
+  expect(stepText).toContain("MANIFOLD_SOLID_BREP")
+  expect(stepText.match(/MAPPED_ITEM/g) ?? []).toHaveLength(0)
+
+  const solidCount = (stepText.match(/MANIFOLD_SOLID_BREP/g) || []).length
+  expect(solidCount).toBeGreaterThanOrEqual(3)
+
+  const occtResult = await importStepWithOcct(stepText)
+  expect(occtResult.success).toBe(true)
+  expect(occtResult.meshes.length).toBeGreaterThanOrEqual(3)
+}, 30000)


### PR DESCRIPTION
Fixes #6.

## Summary
- Treat `model_step_url` components as covered only when `includeExternalMeshes` is enabled.
- When external meshes are disabled, strip external model URLs and render the component as a generated bounding box.
- Add a `basics06` regression test covering the fallback path so STEP-backed components do not disappear.

## Verification
- `npm run build`
- local smoke: `includeComponents: true`, `includeExternalMeshes: false` now emits 3 `MANIFOLD_SOLID_BREP` entries and 0 `MAPPED_ITEM` entries for `basics06`.
- local smoke: existing `includeExternalMeshes: true` fixture path still emits 3 solids and 2 mapped items.

Note: I could not run `bun test` in this environment because Bun is not installed.

/claim #6