### PR TITLE
fix: determine why rectangles are missing in output

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -592,13 +592,15 @@ export async function circuitJsonToStep(
   if (options.includeComponents) {
     // Build set of pcb_component_ids covered by cad_components with model_step_url
     const pcbComponentIdsWithStepUrl = new Set<string>()
-    for (const item of circuitJson) {
-      if (
-        item.type === "cad_component" &&
-        item.model_step_url &&
-        item.pcb_component_id
-      ) {
-        pcbComponentIdsWithStepUrl.add(item.pcb_component_id)
+    if (options.includeExternalMeshes) {
+      for (const item of circuitJson) {
+        if (
+          item.type === "cad_component" &&
+          item.model_step_url &&
+          item.pcb_component_id
+        ) {
+          pcbComponentIdsWithStepUrl.add(item.pcb_component_id)
+        }
       }
     }
 


### PR DESCRIPTION
/claim #6

## Summary

Fixes the issue where rectangles (component fallback boxes) were missing from STEP output when includeExternalMeshes was false.

## Root Cause
The pcbComponentIdsWithStepUrl set was being populated unconditionally from ALL cad_components with model_step_url, regardless of whether includeExternalMeshes was enabled. This caused pcb_components that had corresponding cad_components with STEP URLs to be completely skipped from fallback box generation when includeExternalMeshes was false.

## Fix
Only populate pcbComponentIdsWithStepUrl when includeExternalMeshes is true. When includeExternalMeshes is false, all components (including those with STEP URLs) should still receive fallback box geometry.

## Testing
All 13 existing tests pass.